### PR TITLE
feat: configurable show timeout

### DIFF
--- a/Peer.Domain/Commands/Config.cs
+++ b/Peer.Domain/Commands/Config.cs
@@ -36,7 +36,7 @@ namespace Peer.Domain.Commands
                 // Use this option as an alternative to `Orgs`
                 ""ExcludedOrgs"": [],
                 // The number of pull requests to include in your search results (min: 1, max: 100, default: 20)
-                ""Count"": 7
+                ""Count"": 30
             }
         }]
     }

--- a/Peer.Domain/Commands/Config.cs
+++ b/Peer.Domain/Commands/Config.cs
@@ -11,6 +11,8 @@ namespace Peer.Domain.Commands
         private const string _configHelp = @"
 {
     ""Peer"": {
+    //optional: The amount of time to wait for the show command to fetch pull request info
+    ""ShowTimeoutSeconds"": 30
     //optional: The amount of time between calls to providers when using the --watch flag
     ""WatchIntervalSeconds"": 30
     },

--- a/Peer.Domain/Commands/Config.cs
+++ b/Peer.Domain/Commands/Config.cs
@@ -11,29 +11,32 @@ namespace Peer.Domain.Commands
         private const string _configHelp = @"
 {
     ""Peer"": {
-    //optional: The amount of time to wait for the show command to fetch pull request info
-    ""ShowTimeoutSeconds"": 30
-    //optional: The amount of time between calls to providers when using the --watch flag
-    ""WatchIntervalSeconds"": 30
+        // The amount of time to wait for the show command to fetch pull request info (default: 10)
+        ""ShowTimeoutSeconds"": 30
+        // The amount of time between calls to providers when using the --watch flag (default: 30)
+        ""WatchIntervalSeconds"": 15
     },
+    // Pull request provider configurations organized by type (currently there's only github!)
     ""Providers"": {
-    //The type of the provider you're configuring (currently there's only github!)
+        // A list of GitHub pull request provider configurations
         ""github"": [{
-            //required: a friendly name for this provider
-            ""Name"": ""required: a friendly name for this provider"",
+            // A friendly name for this provider (required)
+            ""Name"": ""GitHub-Work"",
             ""Configuration"": {
-                //required: your API token
+                // An API token with permission to read issues (required)
+                // You will need to configure SSO on the PAT to see pull requests from organizations that require it
                 ""AccessToken"": """",
-                //optional: the github username you're interested in investigating, alternatively we'll fetch yours from the api
+                // The GitHub username you're interested in investigating (optional)
+                // If not provided we'll fetch the username associated with the AccessToken from the API
                 ""Username"": """",
-                //optional: Orgs can be either be traditional (github, wareismymind) or a username for user's repos 
-                // if left empty we'll look at all orgs available to your user
+                // A list of organizations or other GitHub users whose repos to include pull requests from (default: [])
+                // If the list is empty then we'll include all visible requests regardless of the repo owner
                 ""Orgs"": [""myorg"", ""wareismymind"", ""someuser""],
-                //optional: Orgs that you'd like to exclude from the output, only really makes sense if no orgs are set
+                // A list of organizations or other GitHub users whose repos will be excluded when searching for pull requests (default: [])
+                // Use this option as an alternative to `Orgs`
                 ""ExcludedOrgs"": [],
-                //optional: indicates the number of pull requests that will be listed, should be number between 1 and 100.
-                // if not provided will default to 20.
-                ""Count"": 20
+                // The number of pull requests to include in your search results (min: 1, max: 100, default: 20)
+                ""Count"": 7
             }
         }]
     }

--- a/Peer.Domain/Commands/Show.cs
+++ b/Peer.Domain/Commands/Show.cs
@@ -51,7 +51,7 @@ namespace Peer.Domain.Commands
                 {
                     prs.Error switch
                     {
-                        ShowError.Timeout => "error: timeout fetching pull request info",
+                        ShowError.Timeout => "error: timeout fetching pull request info; consider increasing the 'ShowTimeoutSeconds' in your peer config",
                         _ => "error: failed to fetch pull request info",
                     },
                 }, token);

--- a/Peer.Domain/Commands/Show.cs
+++ b/Peer.Domain/Commands/Show.cs
@@ -49,7 +49,11 @@ namespace Peer.Domain.Commands
                 _writer.Clear();
                 _writer.Display(new List<string>
                 {
-                    $"error: failed to fetch pull request info",
+                    prs.Error switch
+                    {
+                        ShowError.Timeout => "error: timeout fetching pull request info",
+                        _ => "error: failed to fetch pull request info",
+                    },
                 }, token);
                 return prs.Error;
             }

--- a/Peer/Parsing/PeerOptions.cs
+++ b/Peer/Parsing/PeerOptions.cs
@@ -1,7 +1,8 @@
 ﻿namespace Peer.Parsing
 {
-    public class WatchOptions
+    public class PeerOptions
     {
+        public int? ShowTimeoutSeconds { get; set; }
         public int? WatchIntervalSeconds { get; set; }
     }
 }

--- a/Peer/Program.cs
+++ b/Peer/Program.cs
@@ -218,13 +218,14 @@ namespace Peer
             // expose the new settings until we've settled on some configuration patterns.
             // https://github.com/wareismymind/peer/issues/149
             var watchOptions = configuration.GetSection("Peer")
-                .Get<WatchOptions>()
-                ?? new WatchOptions();
+                .Get<PeerOptions>()
+                ?? new PeerOptions();
 
             var showConfig = new ShowConfigSection();
             if (watchOptions.WatchIntervalSeconds != null)
             {
                 showConfig.WatchIntervalSeconds = watchOptions.WatchIntervalSeconds;
+                showConfig.TimeoutSeconds = watchOptions.ShowTimeoutSeconds;
             }
 
             services.AddSingleton(showConfig.Into());


### PR DESCRIPTION
Adds a configurable show timeout to the existing configuration format.
There is already a TODO to reconsider the configuration shape so this is
a quick/temporary solution until that thinking is done.

Adds a specific error message for timeouts.