### PR TITLE
feat: configurable configfile path

### DIFF
--- a/Peer.Domain/Util/ResultExtensions.cs
+++ b/Peer.Domain/Util/ResultExtensions.cs
@@ -1,0 +1,16 @@
+﻿using wimm.Secundatives;
+
+namespace Peer.Domain.Util;
+
+public static class ResultExtensions
+{
+    public static Result<T, TErr> ValueOr<T, TErr>(this T? value, TErr err)
+    {
+        if (value == null)
+        {
+            return err;
+        }
+
+        return value;
+    }
+}

--- a/Peer.UnitTests/Apps/AppBuilderTests.cs
+++ b/Peer.UnitTests/Apps/AppBuilderTests.cs
@@ -42,7 +42,7 @@ public class AppBuilderTests
         {
             var called = false;
             var underTest = Construct();
-            underTest.WithSharedServiceConfig(
+            underTest.WithSharedRuntimeConfig(
                 sp =>
                 {
                     called = true;
@@ -60,7 +60,7 @@ public class AppBuilderTests
         {
             var called = false;
             var underTest = Construct();
-            underTest.WithSharedServiceConfig(
+            underTest.WithSharedRuntimeConfig(
                 sp =>
                 {
                     called = true;

--- a/Peer/Apps/AppBuilder/AppBuilder.cs
+++ b/Peer/Apps/AppBuilder/AppBuilder.cs
@@ -36,7 +36,7 @@ public class AppBuilder
         return this;
     }
 
-    public AppBuilder WithSharedServiceConfig(Func<IServiceCollection, Result<IServiceCollection, ConfigError>> config)
+    public AppBuilder WithSharedRuntimeConfig(Func<IServiceCollection, Result<IServiceCollection, ConfigError>> config)
     {
         _services.AddSingleton<IServiceSetupHandler>(new FuncServiceSetupHandler(config));
         return this;

--- a/Peer/Handlers/ConfigEditHandler.cs
+++ b/Peer/Handlers/ConfigEditHandler.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Peer.Apps;
 using Peer.ConfigSections;
 using Peer.Domain.Commands;
+using Peer.Parsing;
 using Peer.Verbs;
 using wimm.Secundatives;
 
@@ -12,13 +13,20 @@ namespace Peer.Handlers;
 
 public class ConfigEditHandler : IHandler<ConfigEditOptions>
 {
+    private readonly PeerEnvironmentOptions _opts;
+
+    public ConfigEditHandler(PeerEnvironmentOptions opts)
+    {
+        _opts = opts;
+    }
+
     public async Task<int> HandleAsync(ConfigEditOptions opts, IServiceCollection services, CancellationToken token = default)
     {
         services.AddSingleton<ConfigEdit>();
         services.AddSingleton(sp =>
         {
             var config = sp.GetRequiredService<IConfiguration>();
-            return new ConfigEditConfig(config["Editor"], Constants.DefaultConfigPath);
+            return new ConfigEditConfig(_opts.Editor, _opts.ConfigPath);
         });
 
         var sp = services.BuildServiceProvider();

--- a/Peer/Handlers/ConfigInitHandler.cs
+++ b/Peer/Handlers/ConfigInitHandler.cs
@@ -5,12 +5,15 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Peer.Apps;
 using Peer.ConfigSections;
+using Peer.Parsing;
 using Peer.Verbs;
 
 namespace Peer.Handlers;
 
 public class ConfigInitHandler : IHandler<ConfigInitOptions>
 {
+    private readonly PeerEnvironmentOptions _opts;
+
     private const string _defaultConfig = @"
 {
     ""Peer"": {
@@ -46,16 +49,21 @@ public class ConfigInitHandler : IHandler<ConfigInitOptions>
 }
 ";
 
+    public ConfigInitHandler(PeerEnvironmentOptions opts)
+    {
+        _opts = opts;
+    }
+
     public async Task<int> HandleAsync(ConfigInitOptions opts, IServiceCollection services, CancellationToken token = default)
     {
-        if (File.Exists(Constants.DefaultConfigPath) && !opts.Force)
+        if (File.Exists(_opts.ConfigPath) && !opts.Force)
         {
             var forceName = opts.GetOptionLongName(nameof(opts.Force));
             Console.WriteLine($"You already have a config file! If you want it overwritten use the --{forceName} option");
             return 1;
         }
 
-        await using var file = File.Create(Constants.DefaultConfigPath);
+        await using var file = File.Create(_opts.ConfigPath);
         await using var writer = new StreamWriter(file);
         await writer.WriteAsync(_defaultConfig);
         return 0;

--- a/Peer/Handlers/ConfigShowHandler.cs
+++ b/Peer/Handlers/ConfigShowHandler.cs
@@ -5,26 +5,34 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Peer.Apps;
 using Peer.ConfigSections;
+using Peer.Parsing;
 using Peer.Verbs;
 
 namespace Peer.Handlers;
 
 public class ConfigShowHandler : IHandler<ConfigShowOptions>
 {
+    private readonly PeerEnvironmentOptions _opts;
+
+    public ConfigShowHandler(PeerEnvironmentOptions opts)
+    {
+        _opts = opts;
+    }
+
     public async Task<int> HandleAsync(
         ConfigShowOptions opts,
         IServiceCollection services,
         CancellationToken token = default)
     {
-        if (!File.Exists(Constants.DefaultConfigPath))
+        if (!File.Exists(_opts.ConfigPath))
         {
 
             await Console.Error.WriteLineAsync($"You don't have a config! User config --init to create a default config");
             return 1;
         }
 
-        var text = await File.ReadAllTextAsync(Constants.DefaultConfigPath, token);
-        Console.WriteLine($"//Path: {Constants.DefaultConfigPath}");
+        var text = await File.ReadAllTextAsync(_opts.ConfigPath, token);
+        Console.WriteLine($"// Path: {_opts.ConfigPath}");
         Console.WriteLine(text);
         return 0;
     }

--- a/Peer/Parsing/PeerOptions.cs
+++ b/Peer/Parsing/PeerOptions.cs
@@ -1,8 +1,16 @@
-﻿namespace Peer.Parsing
+﻿using Peer.ConfigSections;
+
+namespace Peer.Parsing
 {
     public class PeerOptions
     {
         public int? ShowTimeoutSeconds { get; set; }
         public int? WatchIntervalSeconds { get; set; }
+    }
+
+    public class PeerEnvironmentOptions
+    {
+        public string ConfigPath { get; set; } = Constants.DefaultConfigPath;
+        public string? Editor { get; set; }
     }
 }

--- a/Peer/Program.cs
+++ b/Peer/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,14 +39,34 @@ namespace Peer
             };
 
             Console.OutputEncoding = Encoding.UTF8;
-            
+
             var builder = new AppBuilder(new ServiceCollection())
                 .WithParseTimeServiceConfig(SetupParseTimeServices)
-                .WithSharedServiceConfig(SetupServices)
+                .WithSharedRuntimeConfig(SetupServices)
                 .WithConfiguration(configBuilder =>
                 {
-                    configBuilder.AddJsonFile(Constants.DefaultConfigPath, optional: true)
-                        .AddEnvironmentVariables();
+                    var configPath = Environment.GetEnvironmentVariable("PEER_CONFIGPATH")
+                                     ?? Constants.DefaultConfigPath;
+
+                    //
+                    if (configPath.StartsWith("~/"))
+                    {
+
+                        configPath = Path.Join(
+                            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                            configPath[2..]);
+                    }
+
+                    var editor = Environment.GetEnvironmentVariable("EDITOR");
+
+                    configBuilder.AddJsonFile(configPath, optional: true)
+                        .SetFileLoadExceptionHandler(x => x.Ignore = true)
+                        .AddEnvironmentVariables()
+                        .AddInMemoryCollection(new Dictionary<string, string?>
+                        {
+                            ["Peer:Environment:ConfigPath"] = configPath,
+                            ["Peer:Environment:Editor"] = editor
+                        });
                 });
 
             builder.WithVerb<ConfigOptions>(
@@ -221,7 +242,10 @@ namespace Peer
             services.AddSingleton<ISymbolProvider, DefaultEmojiProvider>();
             services.AddSingleton<ICheckSymbolProvider, DefaultEmojiProvider>();
             services.AddSingleton<IRegistrationHandler, GitHubWebRegistrationHandler>();
-
+            services.AddSingleton(
+                sp => sp.GetRequiredService<IConfiguration>()
+                    .GetSection("Peer:Environment")
+                    .Get<PeerEnvironmentOptions>());
             return new Result<IServiceCollection, ConfigError>(services);
         }
 

--- a/Peer/Program.cs
+++ b/Peer/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -57,15 +58,17 @@ namespace Peer
                     }
 
                     var editor = Environment.GetEnvironmentVariable("EDITOR");
+                    var inMemory = new Dictionary<string, string?>
+                    {
+                        ["Peer:Environment:ConfigPath"] = configPath,
+                        ["Peer:Environment:Editor"] = editor
+                    };
 
-                    configBuilder.AddJsonFile(configPath, optional: true)
+                    configBuilder
+                        .AddInMemoryCollection(inMemory)
+                        .AddJsonFile(configPath, optional: true)
                         .SetFileLoadExceptionHandler(x => x.Ignore = true)
-                        .AddEnvironmentVariables()
-                        .AddInMemoryCollection(new Dictionary<string, string?>
-                        {
-                            ["Peer:Environment:ConfigPath"] = configPath,
-                            ["Peer:Environment:Editor"] = editor
-                        });
+                        .AddEnvironmentVariables();
                 });
 
             builder.WithVerb<ConfigOptions>(

--- a/Peer/Program.cs
+++ b/Peer/Program.cs
@@ -48,7 +48,6 @@ namespace Peer
                     var configPath = Environment.GetEnvironmentVariable("PEER_CONFIGPATH")
                                      ?? Constants.DefaultConfigPath;
 
-                    //
                     if (configPath.StartsWith("~/"))
                     {
 

--- a/Peer/Properties/launchSettings.json
+++ b/Peer/Properties/launchSettings.json
@@ -2,9 +2,9 @@
   "profiles": {
     "Peer": {
       "commandName": "Project",
-      "commandLineArgs": "config show,",
+      "commandLineArgs": "config edit",
       "environmentVariables": {
-        "PEER_CONFIGPATH": "~/.config/mynewpeer.json"
+        "EDITOR": "code -r"
       }
     }
   }

--- a/Peer/Properties/launchSettings.json
+++ b/Peer/Properties/launchSettings.json
@@ -2,7 +2,10 @@
   "profiles": {
     "Peer": {
       "commandName": "Project",
-      "commandLineArgs": "show"
+      "commandLineArgs": "config show,",
+      "environmentVariables": {
+        "PEER_CONFIGPATH": "~/.config/mynewpeer.json"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ Peer requires a few things to run properly on different platforms. This list may
 
 ## Environment variables
 
-All of peer configuration can be done either in an environment variable or within the config file. Nesting is done in environment variables with double underscores. So to set WatchIntervalSeconds variable you can simply do 
+Peer configuration can be specified in the config file or in environment variables. Environment variables take precedence over the config file. When using environment variables, the levels of nesting are represented using double underscores. For example, the environment variable `PEER__WATCHINTERVALSECONDS` would override the `Peer.WatchInvervalSeconds` value in the config file.
 
-in sh-like terminals
-
-```sh
+Setting a config variable in sh-like shells
+\```
 export PEER__WATCHINTERVALSECONDS=30
-```
+\```
 
-or in powershell/pwsh
 
-```powershell
-$env:PEER__WATCHINTERVALSECONDS=30 
-```
+Setting a config variable in pwsh/powershell
+\```
+$env:PEER__WATCHINTERVALSECONDS = 20
+\```
+
 
 Some specially named variables are respected during the config load and editor opening commands:
 

--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ Peer requires a few things to run properly on different platforms. This list may
 Peer configuration can be specified in the config file or in environment variables. Environment variables take precedence over the config file. When using environment variables, the levels of nesting are represented using double underscores. For example, the environment variable `PEER__WATCHINTERVALSECONDS` would override the `Peer.WatchInvervalSeconds` value in the config file.
 
 Setting a config variable in sh-like shells
-\```
+```
 export PEER__WATCHINTERVALSECONDS=30
-\```
+```
 
 
 Setting a config variable in pwsh/powershell
-\```
+```
 $env:PEER__WATCHINTERVALSECONDS = 20
-\```
+```
 
 
 Some specially named variables are respected during the config load and editor opening commands:

--- a/README.md
+++ b/README.md
@@ -85,3 +85,24 @@ Peer requires a few things to run properly on different platforms. This list may
 - Tier 3 (We don't have the hardware to test but we'll do our best!)
   - win-arm64
   - osx-arm64
+
+## Environment variables
+
+All of peer configuration can be done either in an environment variable or within the config file. Nesting is done in environment variables with double underscores. So to set WatchIntervalSeconds variable you can simply do 
+
+in sh-like terminals
+
+```sh
+export PEER__WATCHINTERVALSECONDS=30
+```
+
+or in powershell/pwsh
+
+```powershell
+$env:PEER__WATCHINTERVALSECONDS=30 
+```
+
+Some specially named variables are respected during the config load and editor opening commands:
+
+- `PEER_CONFIGPATH` if this is set then peer will look for its config there instead of the default locations
+- `EDITOR` peer will invoke your editor for commands that require it such as `config edit`. If this variable isn't set peer will open it using the default handler on your operating system


### PR DESCRIPTION
Create a new set of options PeerEnvironmentOptions that handle things that depend on the terminal config primarily. Moved EDITOR into there instead of grabbing the variable from the env manually which means we can have it set in Peer__Environment instead and added Peer:Environment:ConfigPath

I pull from PEER_CONFIGPATH directly for ergonomics. Moved to injecting those into all places that the default path had previously been used.

closes #168 